### PR TITLE
Updated pane.less

### DIFF
--- a/styles/panes.less
+++ b/styles/panes.less
@@ -11,6 +11,10 @@
 atom-pane-container {
   atom-pane {
     background-color: lighten(@app-background-color, 4%);
+    
+    .item-views {
+        background:@app-background-color !important;
+    }
 
     &:focus {
       background-color: @app-background-color;


### PR DESCRIPTION
The default background (when there was nothing on the editor area) was white, and it was hurting my eyes
(because I code in a cave, and I hate light — Like a considerable amount of developers :) )

Anyways, this little patch seems to do the trick.
I would prefer a solution w/o an `!important` declarative; however, I did not too much dive into the specificity tree to sort it out.
